### PR TITLE
Make workflow dispatchable

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,9 +1,19 @@
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
-change-title-escapes: '\<*_&@`' # Disables mentions and codeblocks
-template: |
-  ## Changes
+change-title-escapes: '\<*_&`'
 
-  $CHANGES
+# These labels are enforced with the require-labels workflow
+exclude-labels:
+  - Internal
+  - Trivial
+categories:
+  - title: Features
+    labels:
+      - Feature
+  - title: Fixes
+    labels:
+      - Fix
+
+template: ""
 
 # Automatically bump the version in this fashion by adding these labels to your PR.
 version-resolver:
@@ -21,14 +31,3 @@ version-resolver:
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
-# These labels are enforced with the require-labels workflow
-exclude-labels:
-  - Internal
-  - Trivial
-categories:
-  - title: Features
-    labels:
-      - Feature
-  - title: Fixes
-    labels:
-      - Fix

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,27 @@
 name: Release Drafter
 
 on:
-  push:
-    branches:
-      - release
+  # push:
+  #   branches:
+  #     - release
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Release version
+        default: Computed by release drafter using config in  `.github/release-drafter.yml`
+      header:
+        description: Markdown added before the template body
+      name:
+        description: Release name
+        default: Computed using `name-template` in `.github/release-drafter.yml`
+      tag:
+        description: Release tag
+        default: Computed using `tag-template` in `.github/release-drafter.yml`
+      publish:
+        description: Publish release?
+        type: boolean
+        default: true
+
 
 permissions:
   contents: read
@@ -20,6 +38,10 @@ jobs:
     steps:
       - uses: release-drafter/release-drafter@v5
         with:
-          publish: true
+          name: ${{ inputs.name }}
+          tag: ${{ inputs.tag }}
+          header: ${{ inputs.header }}
+          version: ${{ inputs.version }}
+          publish: ${{ inputs.publish }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,4 +1,4 @@
-name: Release Drafter
+name: Releaser
 
 on:
   # push:
@@ -27,7 +27,7 @@ permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  release:
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -1,4 +1,8 @@
 name: Releaser
+run-name: Create a release of ${{ github.ref }} by @${{ github.actor }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   # push:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Release Workflow
 
 - Manually update the `release` branch: https://github.com/urcomputeringpal/release-drafter-demo/compare/release...main
-- Observe new releases be created automatically
+- Create a release with the [releaser workflow](https://github.com/urcomputeringpal/release-drafter-demo/actions/workflows/releaser.yml)
 
 # Features
 


### PR DESCRIPTION
Switches from triggering releases on push to the `release` branch to manually dispatched events that allow version, name, etc, to be overridden.